### PR TITLE
IIQ-3 adding Native password rule to HR Employees APP

### DIFF
--- a/identityiq-config/applications/App.HREmployees.xml
+++ b/identityiq-config/applications/App.HREmployees.xml
@@ -83,6 +83,7 @@
         </value>
       </entry>
       <entry key="templateApplication" value="DelimitedFile Template"/>
+      <entry key="identityCreationRule" value="SetNativePasswordRule"/>
     </Map>
   </Attributes>
   <Owner>

--- a/identityiq-config/rules/SetNativePasswordRule.xml
+++ b/identityiq-config/rules/SetNativePasswordRule.xml
@@ -1,0 +1,23 @@
+<Rule name="SetNativePasswordRule" type="IdentityCreation">
+  <Description>
+    Sets the native SailPoint password to "Password123" only when a new Identity is created via the HR Employees authoritative source.
+  </Description>
+  <Source>
+    <![CDATA[
+    import sailpoint.object.Identity;
+
+    // Check if the identity is being newly created
+    // IdentityCreation rules ONLY trigger on creation, but this is extra safety
+    if (identity != null && !identity.isManuallyCorrelated()) {
+        
+        // Log the action (optional - visible in logs if Rule debugging is enabled)
+        log.info("SetNativePasswordRule: Setting native password for new identity: " + identity.getName());
+
+        // Set a hardcoded password
+        identity.setPassword("Password123");
+    }
+
+    return identity;
+    ]]>
+  </Source>
+</Rule>


### PR DESCRIPTION
Adding the HR Employees app to overwrite existing, only difference is that the application now references the rule "SetNavtivePassword" which is a rule created also on this branch to set the default password on an Identity every time an Identity is created via the trusted source (HR Employees).